### PR TITLE
[euscollada/parseColladaBase.py] use different load function for different PyYAML version

### DIFF
--- a/euscollada/scripts/parseColladaBase.py
+++ b/euscollada/scripts/parseColladaBase.py
@@ -407,7 +407,11 @@ class yamlParser:
     yaml_data = None
 
     def load(self, fname):
-        self.yaml_data = yaml.load(open(fname).read())
+        from packaging import version
+        if version.parse(yaml.__version__) > version.parse('5.4.1'):
+            self.yaml_data = yaml.load(open(fname).read(), Loader=yaml.SafeLoader)
+        else:
+            self.yaml_data = yaml.load(open(fname).read())
 
     def add_sensor(self, xml_obj):
         if 'sensors' in self.yaml_data and self.yaml_data['sensors']:


### PR DESCRIPTION
yaml.load function requires Loader argument to be explicitly indicated after PyYAML version '5.4.1'

https://github.com/yaml/pyyaml/issues/576
https://github.com/yaml/pyyaml/pull/561 -- [always require `Loader` arg to `yaml.load()`](https://github.com/yaml/pyyaml/releases/tag/6.0#:~:text=https%3A//github.com/yaml/pyyaml/pull/561%20%2D%2D%20always%20require%20%60Loader%60%20arg%20to%20%60yaml.load()%60)

Check PyYAML version before using load function.