### PR TITLE
[euscollada/parseColladaBase.py] always explicitly indicating SafeLoader when using yaml.load

### DIFF
--- a/euscollada/scripts/parseColladaBase.py
+++ b/euscollada/scripts/parseColladaBase.py
@@ -407,7 +407,7 @@ class yamlParser:
     yaml_data = None
 
     def load(self, fname):
-        self.yaml_data = yaml.load(open(fname).read())
+        self.yaml_data = yaml.load(open(fname).read(), Loader=yaml.SafeLoader)
 
     def add_sensor(self, xml_obj):
         if 'sensors' in self.yaml_data and self.yaml_data['sensors']:


### PR DESCRIPTION
Same to the [last PR](https://github.com/ban-masa/jsk_model_tools/pull/1):

yaml.load function requires Loader argument to be explicitly indicated after PyYAML version '5.4.1'

https://github.com/yaml/pyyaml/issues/576
https://github.com/yaml/pyyaml/pull/561 -- [always require Loader arg to yaml.load()](https://github.com/yaml/pyyaml/releases/tag/6.0#:~:text=https%3A//github.com/yaml/pyyaml/pull/561%20%2D%2D%20always%20require%20%60Loader%60%20arg%20to%20%60yaml.load()%60)

Always explicitly indicating Loader type to SafeLoader with no need of comparing PyYAML version may be a better solution?
(Though the [default Loader is FullLoader](https://github.com/yaml/pyyaml/blob/b79e34b37e676371a6a104970a8a944fb514b679/lib/yaml/__init__.py#L110C6-L110C28) before and including version '5.4.1')